### PR TITLE
Phase3-Step1: feat(symtable): implement lexical scoping

### DIFF
--- a/include/symbols.h
+++ b/include/symbols.h
@@ -6,12 +6,18 @@
 typedef struct {
     int id;
     char lexeme[100];
-    tokenType type;
+    tokenType type;      // Para TKN_IDENTIFIER
+    tokenType data_type; // Para el tipo semantico: TKN_INT, TKN_FLOAT, etc.
+    int scope_level;
 } symbol;
 
 void init_symbol_table();
 
-int install_symbol(const char *lexeme, tokenType type);
+void enter_scope();
+void exit_scope();
+
+int install_symbol(const char *lexeme, tokenType type, tokenType data_type);
+int lookup_symbol(const char *lexeme);
 void print_symbol_table();
 
 #endif

--- a/src/parser.c
+++ b/src/parser.c
@@ -139,7 +139,7 @@ void parse_declaration(Parser *p) {
     advance(p); 
 
     if (p->current_token.type == TKN_IDENTIFIER) {
-        install_symbol(p->current_token.lexeme, type);
+        install_symbol(p->current_token.lexeme, TKN_IDENTIFIER, type);
         advance(p);
     } else {
         parser_error(p, "Se esperaba un nombre de variable");
@@ -189,6 +189,7 @@ void parse_write(Parser *p) {
 // FOR -> for + DECLARACION/ASIGNACION , OPERACION_LOGICA , OPERACION_UNARIA + CUERPO
 void parse_for(Parser *p) {
     match(p, TKN_FOR);
+    enter_scope();
     
     // Parte 1: Declaracion o Asignacion
     if (p->current_token.type == TKN_INT || p->current_token.type == TKN_FLOAT || 
@@ -212,6 +213,7 @@ void parse_for(Parser *p) {
     
     // Cuerpo
     parse_block(p);
+    exit_scope();
 }
 
 // WHILE -> while + OPERACION_LOGICA + CUERPO
@@ -232,10 +234,14 @@ void parse_if(Parser *p) {
 void parse_proc(Parser *p) {
     match(p, TKN_PROC);
     match(p, TKN_IDENTIFIER);
+    
+    enter_scope();
     match(p, TKN_LPAREN);
     parse_parameters(p);
     match(p, TKN_RPAREN);
+    
     parse_block(p);
+    exit_scope();
 }
 
 // PARAMETROS -> (TIPO_DATO + IDENTIFICADOR)
@@ -245,7 +251,12 @@ void parse_parameters(Parser *p) {
     do {
         if (p->current_token.type == TKN_INT || p->current_token.type == TKN_FLOAT || 
             p->current_token.type == TKN_STRING || p->current_token.type == TKN_BOOL) {
+            tokenType type = p->current_token.type;
             advance(p);
+            
+            if (p->current_token.type == TKN_IDENTIFIER) {
+                install_symbol(p->current_token.lexeme, TKN_IDENTIFIER, type);
+            }
             match(p, TKN_IDENTIFIER);
         } else {
             parser_error(p, "Se esperaba un tipo de dato en parametro");
@@ -263,12 +274,14 @@ void parse_parameters(Parser *p) {
 // CUERPO -> { INSTRUCCION* }
 void parse_block(Parser *p) {
     match(p, TKN_LBRACE);
+    enter_scope();
     while (p->current_token.type != TKN_RBRACE && p->current_token.type != TKN_EOF && !p->has_error) {
         parse_instruction(p);
         if(p->has_error) {
             synchronize(p);
         }
     }
+    exit_scope();
     match(p, TKN_RBRACE);
 }
 
@@ -353,7 +366,7 @@ ASTNode* parse_factor(Parser *p) {
         
         NodeType node_type = (t.type == TKN_IDENTIFIER) ? NODE_IDENTIFIER : NODE_LITERAL;
         
-        install_symbol(t.lexeme, t.type);
+        install_symbol(t.lexeme, t.type, t.type);
         advance(p);
         return create_node(node_type, t);
     } else if (t.type == TKN_LPAREN) {

--- a/src/symbols.c
+++ b/src/symbols.c
@@ -7,23 +7,47 @@
 
 symbol symbol_table[MAX_SYMBOLS];
 int symbol_count = 0;
+int current_scope = 0;
 
 void init_symbol_table() {
     symbol_count = 0;
+    current_scope = 0;
 }
 
-int install_symbol(const char *lexeme, tokenType type) {
-    // Buscar si existe el simbolo
-    for (int i = 0; i < symbol_count; i++) {
-        if (strcmp(symbol_table[i].lexeme, lexeme) == 0) {
+void enter_scope() {
+    current_scope++;
+}
+
+void exit_scope() {
+    if (current_scope > 0) {
+        current_scope--;
+    }
+}
+
+// Búsqueda de un símbolo, de su ámbito más interno al más global
+int lookup_symbol(const char *lexeme) {
+    for (int i = symbol_count - 1; i >= 0; i--) {
+        if (strcmp(symbol_table[i].lexeme, lexeme) == 0 && symbol_table[i].scope_level <= current_scope) {
+            return symbol_table[i].id;
+        }
+    }
+    return -1; // No se encuentra en ningun scope válido
+}
+
+int install_symbol(const char *lexeme, tokenType type, tokenType data_type) {
+    // Buscar si ya existe en el MISMO ámbito
+    for (int i = symbol_count - 1; i >= 0; i--) {
+        // Terminar apenas salgamos del scope actual, no importa que en global haya otro nombre
+        if (symbol_table[i].scope_level < current_scope) break;
+        
+        if (strcmp(symbol_table[i].lexeme, lexeme) == 0 && symbol_table[i].scope_level == current_scope) {
             return symbol_table[i].id; // Si existe, retornar ID
         }
     }
 
-    // Si no existe, agregar el simbolo
-
-    if (symbol_count >= MAX_SYMBOLS) { // Tabla llena
-        printf("Error: Tabla de simbolos llena.\n");
+    // Si no existe en el mismo ambito, lo agregamos
+    if (symbol_count >= MAX_SYMBOLS) {
+        printf("Error Semántico: Tabla de simbolos llena.\n");
         return -1;
     }
 
@@ -31,6 +55,8 @@ int install_symbol(const char *lexeme, tokenType type) {
     new_sym.id = symbol_count;
     strcpy(new_sym.lexeme, lexeme);
     new_sym.type = type;
+    new_sym.data_type = data_type;
+    new_sym.scope_level = current_scope;
 
     symbol_table[symbol_count] = new_sym;
     symbol_count++;
@@ -40,13 +66,21 @@ int install_symbol(const char *lexeme, tokenType type) {
 
 void print_symbol_table() {
     printf("\n=== TABLA DE SIMBOLOS ===\n");
-    printf("%-5s | %-20s | %-15s\n", "ID", "LEXEMA", "TIPO");
-    printf("----------------------------------------------\n");
+    printf("%-5s | %-20s | %-15s | %-6s\n", "ID", "LEXEMA", "TIPO DATO", "SCOPE");
+    printf("----------------------------------------------------------\n");
     for (int i = 0; i < symbol_count; i++) {
-        printf("%-5d | %-20s | %s\n", 
+        char type_str[50];
+        if (symbol_table[i].type == TKN_IDENTIFIER) {
+            strcpy(type_str, token_type_to_str(symbol_table[i].data_type));
+        } else {
+            strcpy(type_str, token_type_to_str(symbol_table[i].type));
+        }
+
+        printf("%-5d | %-20s | %-15s | %-6d\n", 
             symbol_table[i].id, 
             symbol_table[i].lexeme, 
-            token_type_to_str(symbol_table[i].type));
+            type_str,
+            symbol_table[i].scope_level);
     }
-    printf("----------------------------------------------\n");
+    printf("----------------------------------------------------------\n");
 }


### PR DESCRIPTION
Adds `scope_level` and `data_type` to symbol entries. Introduces `enter_scope`, `exit_scope`, and scope-aware `lookup_symbol`. Updates `install_symbol` to prevent redefinition within the same scope. Integrates scope management into parser for `for`, `proc`, and `block` statements.